### PR TITLE
[feat/cart-ui] 장바구니 페이지 UI 퍼블리싱

### DIFF
--- a/src/assets/images/icon_basket_main.svg
+++ b/src/assets/images/icon_basket_main.svg
@@ -1,0 +1,9 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 15H24.9698C25.1133 15 25.2367 15.1016 25.2642 15.2424L33.5385 57.5C34.1911 60.3333 37.2587 66 44.3077 66C51.3566 66 72.373 66 82 66" stroke="#DDDDDD" stroke-width="7" stroke-linecap="square"/>
+<path d="M30 26.5H87.3695C87.4353 26.5 87.4832 26.5625 87.4661 26.626L80.5199 52.426C80.5082 52.4697 80.4686 52.5 80.4234 52.5H34" stroke="#DDDDDD" stroke-width="7" stroke-linecap="square"/>
+<path d="M47.5 27.5L50 52" stroke="#DDDDDD" stroke-width="7" stroke-linecap="square"/>
+<path d="M68 27.5L67 51.5" stroke="#DDDDDD" stroke-width="7" stroke-linecap="square"/>
+<path d="M31 39.5H82.5" stroke="#DDDDDD" stroke-width="7" stroke-linecap="square"/>
+<circle cx="39" cy="78" r="5.5" fill="#DDDDDD" stroke="#DDDDDD"/>
+<circle cx="78" cy="78" r="5.5" fill="#DDDDDD" stroke="#DDDDDD"/>
+</svg>

--- a/src/assets/images/index.ts
+++ b/src/assets/images/index.ts
@@ -1,1 +1,1 @@
-export { default as iconBasketMain } from './icon_basket_main.svg';
+export { default as basketMainIcon } from './icon_basket_main.svg';

--- a/src/assets/images/index.ts
+++ b/src/assets/images/index.ts
@@ -1,0 +1,1 @@
+export { default as iconBasketMain } from './icon_basket_main.svg';

--- a/src/assets/images/index.ts
+++ b/src/assets/images/index.ts
@@ -1,1 +1,1 @@
-export { default as basketMainIcon } from './icon_basket_main.svg';
+export { default as iconBasketMain } from './icon_basket_main.svg';

--- a/src/components/cart/CartComponent.tsx
+++ b/src/components/cart/CartComponent.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function CartComponent() {
-  return <div></div>;
-}
-
-export default CartComponent;

--- a/src/components/cart/EmptyCartView.tsx
+++ b/src/components/cart/EmptyCartView.tsx
@@ -1,4 +1,4 @@
-import { iconBasketMain } from 'assets/images';
+import { basketMainIcon } from 'assets/images';
 import styled from 'styled-components';
 
 function EmptyCartView() {
@@ -9,7 +9,7 @@ function EmptyCartView() {
         <CartTabItem>정기배송(0)</CartTabItem>
       </StCartTab>
       <StEmptyCart>
-        <StIconBasket src={iconBasketMain} />
+        <StBasketMainIcon src={basketMainIcon} />
         <h1>
           장바구니에
           <br />
@@ -88,7 +88,7 @@ const StEmptyCart = styled.section`
   }
 `;
 
-const StIconBasket = styled.img`
+const StBasketMainIcon = styled.img`
   width: 10rem;
   height: 10rem;
   margin-bottom: 0.8rem;

--- a/src/components/cart/EmptyCartView.tsx
+++ b/src/components/cart/EmptyCartView.tsx
@@ -1,4 +1,4 @@
-import { basketMainIcon } from 'assets/images';
+import { iconBasketMain } from 'assets/images';
 import styled from 'styled-components';
 
 function EmptyCartView() {
@@ -9,7 +9,7 @@ function EmptyCartView() {
         <CartTabItem>정기배송(0)</CartTabItem>
       </StCartTab>
       <StEmptyCart>
-        <StBasketMainIcon src={basketMainIcon} />
+        <StIconBasketMain src={iconBasketMain} />
         <h1>
           장바구니에
           <br />
@@ -88,7 +88,7 @@ const StEmptyCart = styled.section`
   }
 `;
 
-const StBasketMainIcon = styled.img`
+const StIconBasketMain = styled.img`
   width: 10rem;
   height: 10rem;
   margin-bottom: 0.8rem;

--- a/src/components/cart/EmptyCartView.tsx
+++ b/src/components/cart/EmptyCartView.tsx
@@ -1,0 +1,106 @@
+import { iconBasketMain } from 'assets/images';
+import styled from 'styled-components';
+
+function EmptyCartView() {
+  return (
+    <>
+      <StCartTab>
+        <CartTabItem>일반구매(0)</CartTabItem>
+        <CartTabItem>정기배송(0)</CartTabItem>
+      </StCartTab>
+      <StEmptyCart>
+        <StIconBasket src={iconBasketMain} />
+        <h1>
+          장바구니에
+          <br />
+          담긴 상품이 없습니다.
+        </h1>
+        <h2>
+          로그인을 하시면, 장바구니에 보관된 상품을
+          <br />
+          확인하실 수 있습니다.
+        </h2>
+        <StLoginButton>로그인</StLoginButton>
+      </StEmptyCart>
+    </>
+  );
+}
+
+export default EmptyCartView;
+
+const StCartTab = styled.nav`
+  display: flex;
+
+  height: 4.4rem;
+
+  font-weight: ${(props) => props.theme.fontWeight.semiBold};
+  font-size: 1.4rem;
+
+  & > div:first-of-type {
+    color: ${(props) => props.theme.color.blue01};
+    border-bottom: 0.2rem solid ${(props) => props.theme.color.blue01};
+  }
+
+  & > div:nth-of-type(2) {
+    color: ${(props) => props.theme.color.black};
+    border-bottom: 0.05rem solid #e4e6e3;
+  }
+`;
+
+const CartTabItem = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+`;
+
+const StEmptyCart = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  height: 47rem;
+  padding: 9rem 6rem 10rem 6rem;
+
+  border-top: 0.05rem solid #e4e6e3;
+  border-bottom: 0.1rem solid #e4e6e3;
+
+  & > h1 {
+    margin-bottom: 3rem;
+
+    color: ${(props) => props.theme.color.gray400};
+    font-size: 1.8rem;
+    letter-spacing: 0.01rem;
+    line-height: 2.1rem;
+
+    text-align: center;
+  }
+
+  & > h2 {
+    margin-bottom: 1.6rem;
+
+    color: ${(props) => props.theme.color.gray500};
+    font-size: 1.6rem;
+    letter-spacing: -0.04em;
+    line-height: 1.9rem;
+
+    text-align: center;
+  }
+`;
+
+const StIconBasket = styled.img`
+  width: 10rem;
+  height: 10rem;
+  margin-bottom: 0.8rem;
+`;
+
+const StLoginButton = styled.button`
+  width: 24.5rem;
+  height: 4.4rem;
+
+  border: 0.1rem solid ${(props) => props.theme.color.blue01};
+  border-radius: 0.4rem;
+  background-color: transparent;
+  color: ${(props) => props.theme.color.blue01};
+  font-size: 1.7rem;
+`;

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import EmptyCartView from 'components/cart/EmptyCartView';
 
 function Cart() {
-  return <div>장바구니에요!</div>;
+  return <EmptyCartView />;
 }
 
 export default Cart;


### PR DESCRIPTION
## 관련 이슈
- close #5 


## PR Point
- 장바구니 페이지 UI를 구현했습니다. 딱히 기능이 없는 곳이라 `EmptyCartView`라는 컴포넌트 하나를 생성했습니다.
- **E4E6E3**가 border에 쓰이는데 색상 컴포넌트에 없어서.. 자주 쓰인다면 형겸쓰 말대로 저희 컬러 팔레트에 넣어놔야할 것 같네요!
- 일반배송/정기배송 밑 border 파란색, 회색이 0.05rem정도 미묘하게 겹쳐 있는데 피그마 참고하여 그대로 구현했습니다.

## 스크린샷
<img width="375" alt="스크린샷 2022-11-16 오후 2 30 17" src="https://user-images.githubusercontent.com/99077953/202091853-6ff7a6bf-e1ae-4ebe-b497-7b8e69680d59.png">
